### PR TITLE
geojson2csv -> geojson2dsv for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/mapbox/geojson2dsv.png)](https://travis-ci.org/mapbox/geojson2dsv)
 
-# geojson2csv
+# geojson2dsv
 
 The reverse of [csv2geojson](https://github.com/mapbox/csv2geojson): shuttle [GeoJSON](http://geojson.org/) points into
 CSV encoding.
@@ -9,7 +9,7 @@ Currently points only.
 
 ## api
 
-### `csvString = geojson2csv(geojsonObject)`
+### `csvString = geojson2dsv(geojsonObject)`
 
 Given a valid GeoJSON object, return a CSV composed of all decodable points.
 

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "author": "Tom MacWright",
   "license": "BSD-2-Clause",
   "bugs": {
-    "url": "https://github.com/mapbox/geojson2csv/issues"
+    "url": "https://github.com/mapbox/geojson2dsv/issues"
   },
-  "homepage": "https://github.com/mapbox/geojson2csv",
+  "homepage": "https://github.com/mapbox/geojson2dsv",
   "dependencies": {
     "dsv": "0.0.3"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1,21 +1,21 @@
-var geojson2csv = require('../');
+var geojson2dsv = require('../');
 var expect = require('expect.js');
 
-describe('geojson2csv', function() {
+describe('geojson2dsv', function() {
     it('encodes a single point', function() {
-        expect(geojson2csv({
+        expect(geojson2dsv({
             type: 'Point',
             coordinates: [0,0]
         })).to.eql('lon,lat\n0,0');
     });
     it('customizes a delimiter', function() {
-        expect(geojson2csv({
+        expect(geojson2dsv({
             type: 'Point',
             coordinates: [0,0]
         }, ';')).to.eql('lon;lat\n0;0');
     });
     it('encodes a feature', function() {
-        expect(geojson2csv({
+        expect(geojson2dsv({
             type: 'Feature',
             geometry: {
                 type: 'Point',
@@ -27,7 +27,7 @@ describe('geojson2csv', function() {
         })).to.eql('a,lon,lat\nb,0,0');
     });
     it('encodes a featurecollection', function() {
-        expect(geojson2csv({
+        expect(geojson2dsv({
             type: 'FeatureCollection',
             features: [{
                 type: 'Feature',
@@ -42,7 +42,7 @@ describe('geojson2csv', function() {
         })).to.eql('a,lon,lat\nb,10,0');
     });
     it('ignores polygons', function() {
-        expect(geojson2csv({
+        expect(geojson2dsv({
             type: 'FeatureCollection',
             features: [{
                 type: 'Feature',


### PR DESCRIPTION
Seems like the name was changed somewhere along the line and is in fact
registered in npm as geojson2dsv. This commit just replaces (most)
instance of geojson2csv with geojson2dsv.
