### PR TITLE
Serialize properties of non-Point features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-node_modules

--- a/index.js
+++ b/index.js
@@ -1,25 +1,19 @@
 var dsv = require('dsv');
+var normalize = require('geojson-normalize');
 
 module.exports = function(_, delim) {
-    switch (_.type) {
-        case 'FeatureCollection':
-            break;
-        case 'Feature':
-            _ = { type: 'FeatureCollection', features: [_] };
-            break;
-        case 'Point':
-            _ = { type: 'FeatureCollection', features: [{ type: 'Feature', properties: {}, geometry: _ }] };
-            break;
-        default:
-            return null;
-    }
+    _ = normalize(_);
 
-    return dsv(delim || ',').format(_.features.filter(function(f) {
-        return f.geometry.type == 'Point';
-    }).map(function(f) {
+    var onlyPoints = _.features.every(function(f) {
+        return f.geometry.type === 'Point';
+    });
+
+    return dsv(delim || ',').format(_.features.map(function(f) {
         var p = JSON.parse(JSON.stringify(f.properties));
-        p.lon = f.geometry.coordinates[0];
-        p.lat = f.geometry.coordinates[1];
+        if (onlyPoints) {
+            p.lon = f.geometry.coordinates[0];
+            p.lat = f.geometry.coordinates[1];
+        }
         return p;
     }));
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "homepage": "https://github.com/mapbox/geojson2dsv",
   "dependencies": {
-    "dsv": "0.0.3"
+    "dsv": "0.0.3",
+    "geojson-normalize": "0.0.0"
   },
   "devDependencies": {
     "expect.js": "~0.2.0",

--- a/test/test.js
+++ b/test/test.js
@@ -41,7 +41,7 @@ describe('geojson2dsv', function() {
             }]
         })).to.eql('a,lon,lat\nb,10,0');
     });
-    it('ignores polygons', function() {
+    it('encodes properties of non-points', function() {
         expect(geojson2dsv({
             type: 'FeatureCollection',
             features: [{
@@ -54,6 +54,30 @@ describe('geojson2dsv', function() {
                     a: 'b'
                 }
             }]
-        })).to.eql('');
+        })).to.eql('a\nb');
+    });
+    it('encodes properties of mixed geometry types', function() {
+        expect(geojson2dsv({
+            type: 'FeatureCollection',
+            features: [{
+                type: 'Feature',
+                geometry: {
+                    type: 'Point',
+                    coordinates: [10,0]
+                },
+                properties: {
+                    a: 'x'
+                }
+            },{
+                type: 'Feature',
+                geometry: {
+                    type: 'Polygon',
+                    coordinates: [[10,0]]
+                },
+                properties: {
+                    a: 'y'
+                }
+            }]
+        })).to.eql('a\nx\ny');
     });
 });


### PR DESCRIPTION
Modified to serialize the properties of non-Point features.
If all features are Points, then lat and lon are still added as columns. If not, then only the properties of each feature are serialized.
